### PR TITLE
Add unified customizable strafe stats HUD with menus, persistence, and spectator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
 # Counter-Strike 1.6 Strafe Stats Plugin
 
 ## Overview
-This AMX Mod X plugin is designed for Counter-Strike 1.6 servers to track and display strafing statistics for players. Strafing is a movement technique used to gain speed while jumping.
+This AMX Mod X plugin tracks and displays strafing statistics for Counter-Strike 1.6 players.  
+Strafing is a movement technique used to gain speed while jumping.  
+The plugin shows strafe count, sync percentage, gain, frames, strafe list and console info.  
+All player preferences are **saved persistently** using FVault (survives reconnects and map changes).
 
 ## Features
-- Tracks the number of strafes performed by players.
-- Calculates synchronization frames during strafes.
-- Displays strafing statistics on the player's HUD and in the console.
-- Toggle the display of statistics for individual players.
+- Strafe stats HUD visible to the player and their spectators
+- Prestrafe speed display
+- Full configuration menu with individual toggles
+- Persistent saving: Stats, Pre-Strafe, Strafes, Sync, Gain, Frames, List and Console Info
+- Works for spectators: they see stats/prestrafe if **they** have toggles enabled
 
 ## Commands
-- **/stats:** Toggles the display of strafing statistics for the player.
-  
-## Native Functions
-1. `get_user_sync(player_id)`: Get synchronization percentage for a specific player.
-2. `get_user_strafes(player_id)`: Get the number of strafes performed by a specific player.
-3. `display_stats(player_id, strafes, sync)`: Display strafing statistics to a specific player.
-4. `get_bool_stats(player_id)`: Get the status of statistics display for a specific player.
-5. `toggle_stats(player_id)`: Toggle the display of strafing statistics for a specific player.
+- `/stats` → Opens the main menu (quick toggles for Stats + Prestrafe + link to detailed settings)
+- `/statsmenu` → Opens the detailed settings menu directly
+- `/pre`, `/showpre`, `/prestrafe` → Quick toggle for Prestrafe (optional)
 
+## Menu System
+### Main Menu (`/stats`)
+- Stats → Toggle overall strafe stats HUD
+- Pre-Strafe → Toggle prestrafe speed display
+- Display Settings → Opens detailed options
 
+### Detailed Settings Menu
+- Strafes → Show number of strafes
+- Sync → Show sync percentage
+- Gain → Show average gain
+- Frames → Show good/total frames
+- List → Show side list of each strafe
+- Console Info → Show detailed info in console
+
+All changes are saved instantly and persist across sessions.
+
+## Credits
+- **MrShark45 & ftl~** 

--- a/include/strafe_globals.inc
+++ b/include/strafe_globals.inc
@@ -19,3 +19,6 @@ new bool:g_bShowConsole[33];
 
 // Prestrafe Toggle
 new bool:g_bShowPre[33];
+
+// Vault ID
+new const g_iVault [] = "stats_settings";

--- a/include/strafe_globals.inc
+++ b/include/strafe_globals.inc
@@ -1,11 +1,21 @@
-// Stats Sync:
+// HUD Sync
 new g_iMainHudSync;
 new g_iStrafeHudSync;
 
-new bool:b_show_stats[33];
-
+// Natives
 new g_iNativeStrafes[33];
 new g_iNativeSync[33];
 
-// Show Pre:
-new bool:b_pre_stats[33];
+// Main Toggle
+new bool:g_bShowStats[33];
+
+// Menu Options
+new bool:g_bShowStrafes[33];
+new bool:g_bShowSync[33];
+new bool:g_bShowGain[33];
+new bool:g_bShowFrames[33];
+new bool:g_bShowStrafeList[33];
+new bool:g_bShowConsole[33];
+
+// Prestrafe Toggle
+new bool:g_bPreStats[33];

--- a/include/strafe_globals.inc
+++ b/include/strafe_globals.inc
@@ -18,4 +18,4 @@ new bool:g_bShowStrafeList[33];
 new bool:g_bShowConsole[33];
 
 // Prestrafe Toggle
-new bool:g_bPreStats[33];
+new bool:g_bShowPre[33];

--- a/include/strafe_menu.inc
+++ b/include/strafe_menu.inc
@@ -7,7 +7,7 @@ public StatsMenu(id)
 	formatex(szItem, sizeof(szItem) - 1, "\wStats %s", g_bShowStats[id] ? "\y[ON]" : "\r[OFF]");
 	menu_additem(menu, szItem, "1");
 
-	formatex(szItem, sizeof(szItem) - 1, "\wPre-Strafe %s", g_bPreStats[id] ? "\y[ON]" : "\r[OFF]");
+	formatex(szItem, sizeof(szItem) - 1, "\wPre-Strafe %s", g_bShowPre[id] ? "\y[ON]" : "\r[OFF]");
 	menu_additem(menu, szItem, "2");
 
 	formatex(szItem, sizeof(szItem) - 1, "\wDisplay Settings");
@@ -30,7 +30,7 @@ public StatsMenu_Handler(id, menu, item){
 
 	switch(choice){
 		case 1: g_bShowStats[id] = !g_bShowStats[id];
-		case 2: g_bPreStats[id] = !g_bPreStats[id];
+		case 2: g_bShowPre[id] = !g_bShowPre[id];
 		case 3: {
 			menu_destroy(menu);
 			SettingsMenu(id);

--- a/include/strafe_menu.inc
+++ b/include/strafe_menu.inc
@@ -38,6 +38,7 @@ public StatsMenu_Handler(id, menu, item){
 		}
 	}
 
+	SaveStatsSettings(id);
 	menu_destroy(menu);
 	StatsMenu(id);
 	return PLUGIN_HANDLED;
@@ -91,7 +92,8 @@ public SettingsMenu_Handler(id, menu, item){
 		case 5: g_bShowStrafeList[id] = !g_bShowStrafeList[id];
 		case 6: g_bShowConsole[id] = !g_bShowConsole[id];
 	}
-
+	
+	SaveStatsSettings(id);
 	menu_destroy(menu);
 	SettingsMenu(id);
 	return PLUGIN_HANDLED;

--- a/include/strafe_menu.inc
+++ b/include/strafe_menu.inc
@@ -1,0 +1,98 @@
+public StatsMenu(id)
+{
+	new menu = menu_create("\r[FWO] \d- \wStatus Menu", "StatsMenu_Handler");
+	
+	new szItem[64];
+
+	formatex(szItem, sizeof(szItem) - 1, "\wStats %s", g_bShowStats[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "1");
+
+	formatex(szItem, sizeof(szItem) - 1, "\wPre-Strafe %s", g_bPreStats[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "2");
+
+	formatex(szItem, sizeof(szItem) - 1, "\wDisplay Settings");
+	menu_additem(menu, szItem, "3");
+
+	menu_setprop(menu, MPROP_EXITNAME, "Exit");
+	menu_display(id, menu, 0);
+	return PLUGIN_HANDLED;
+}
+
+public StatsMenu_Handler(id, menu, item){
+	if(item == MENU_EXIT){
+		menu_destroy(menu);
+		return PLUGIN_HANDLED;
+	}
+
+	new data[6], access, callback;
+	menu_item_getinfo(menu, item, access, data, charsmax(data), _, _, callback);
+	new choice = str_to_num(data);
+
+	switch(choice){
+		case 1: g_bShowStats[id] = !g_bShowStats[id];
+		case 2: g_bPreStats[id] = !g_bPreStats[id];
+		case 3: {
+			menu_destroy(menu);
+			SettingsMenu(id);
+			return PLUGIN_HANDLED;
+		}
+	}
+
+	menu_destroy(menu);
+	StatsMenu(id);
+	return PLUGIN_HANDLED;
+}
+
+public SettingsMenu(id)
+{
+	new menu = menu_create("\r[FWO] \d- \wDisplay Options", "SettingsMenu_Handler");
+	
+	new szItem[64];
+	
+	formatex(szItem, sizeof(szItem) - 1, "\wStrafes %s", g_bShowStrafes[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "1");
+	
+	formatex(szItem, sizeof(szItem) - 1, "\wSync %s", g_bShowSync[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "2");
+	
+	formatex(szItem, sizeof(szItem) - 1, "\wGain %s", g_bShowGain[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "3");
+
+	formatex(szItem, sizeof(szItem) - 1, "\wFrames %s", g_bShowFrames[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "4");
+	
+	formatex(szItem, sizeof(szItem) - 1, "\wList %s", g_bShowStrafeList[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "5");
+
+	formatex(szItem, sizeof(szItem) - 1, "\wConsole Info %s", g_bShowConsole[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "6");
+
+	menu_setprop(menu, MPROP_EXITNAME, "Back");
+	menu_display(id, menu, 0);
+	return PLUGIN_HANDLED;
+}
+
+public SettingsMenu_Handler(id, menu, item){
+	if(item == MENU_EXIT){
+		menu_destroy(menu);
+		StatsMenu(id);
+		return PLUGIN_HANDLED;
+	}
+
+	new data[6], access, callback;
+	menu_item_getinfo(menu, item, access, data, charsmax(data), _, _, callback);
+	new choice = str_to_num(data);
+
+	switch(choice){
+		case 1: g_bShowStrafes[id] = !g_bShowStrafes[id];
+		case 2: g_bShowSync[id] = !g_bShowSync[id];
+		case 3: g_bShowGain[id] = !g_bShowGain[id];
+		case 4: g_bShowFrames[id] = !g_bShowFrames[id];
+		case 5: g_bShowStrafeList[id] = !g_bShowStrafeList[id];
+		case 6: g_bShowConsole[id] = !g_bShowConsole[id];
+	}
+
+	menu_destroy(menu);
+	SettingsMenu(id);
+	return PLUGIN_HANDLED;
+}

--- a/stats.sma
+++ b/stats.sma
@@ -258,12 +258,12 @@ public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodF
 		{
 			iLen += formatex(szStrafesInfo[iLen], charsmax(szStrafesInfo) - iLen, "Strafe: %i^tSync: %i^n", j + 1, strafesSync[j]);
 		}
-		
+
 		set_hudmessage(200, 22, 22, 0.77, 0.4, 0, 0.0, 2.0, 0.2, 0.2, 4);
 		ShowSyncHudMsg(i, g_iStrafeHudSync, "%s", szStrafesInfo);
 
 		set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, 3);
-		ShowSyncHudMsg(i, g_iMainHudSync, "Strafes: %i^nSync: %i%^nFrames: %d/%d^nGain: %.2f", strafes, sync, goodFrames, frames, gain);
+		ShowSyncHudMsg(i, g_iMainHudSync, "Strafes: %i / Sync: %i%^nFrames: %d/%d^nGain: %.2f", strafes, sync, goodFrames, frames, gain);
 		if(g_bShowConsole[i]){
 			client_print(id, print_console, "--- Strafe #%i - Sync: %i%% ---", strafes, sync);
 			client_print(id, print_console, "Strafes: %i^nSync: %i%%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);

--- a/stats.sma
+++ b/stats.sma
@@ -7,7 +7,7 @@
 
 #define PLUGIN "Stats"
 #define VERSION "1.0"
-#define AUTHOR "MrShark45"
+#define AUTHOR "MrShark45 & ftl~"
 
 #define MAX_STRAFES 33
 
@@ -19,6 +19,8 @@ public plugin_init(){
 	register_forward( FM_PlayerPreThink, "fwdPreThink", 0 );
 
 	register_clcmd("say /stats", "toggle_stats");
+	register_clcmd("say /statsmenu", "stats_menu");
+
 	register_clcmd("say /pre", "toggle_pre");
 	register_clcmd("say /showpre", "toggle_pre");
 	register_clcmd("say /prestrafe", "toggle_pre");
@@ -72,7 +74,7 @@ public native_display_stats(NumParams) {
 
 	for(new i = 1; i < 33; i++)
 	{
-		if(!is_user_connected(i) || is_user_alive(i) || !b_show_stats[i] ) continue;
+		if(!is_user_connected(i) || is_user_alive(i) || !g_bShowStats[i] ) continue;
 		
 		if( pev(i, pev_iuser2) == id )
 		{
@@ -84,7 +86,7 @@ public native_display_stats(NumParams) {
 
 public native_get_bool_stats(NumParams){
 	new id = get_param(1);
-	return b_show_stats[id];
+	return g_bShowStats[id];
 }
 
 public native_toggle_stats(NumParams){
@@ -94,7 +96,7 @@ public native_toggle_stats(NumParams){
 
 public native_get_bool_pre(NumParams){
 	new id = get_param(1);
-	return b_pre_stats[id];
+	return g_bPreStats[id];
 }
 
 public native_toggle_pre(NumParams){
@@ -102,19 +104,78 @@ public native_toggle_pre(NumParams){
 	toggle_pre(id);
 }
 
-public client_putinserver(id){
-	b_show_stats[id] = false; // Set to false so stats are OFF by default when the player joins. The player must enable it manually.
-	b_pre_stats[id] = false; // Set to false so Prestrafe is OFF by default (bhop standard). To have it enabled by default (speedrun standard), change to true.
+public client_putinserver(id){ 
+	g_bShowStats[id] = false; // Set to false so stats are OFF by default when the player joins. The player must enable it manually.
+	g_bPreStats[id] = false; // Set to false so Prestrafe is OFF by default (bhop standard). To have it enabled by default (speedrun standard), change to true.
+	g_bShowStrafes[id] = true;
+	g_bShowSync[id] = true;
+	g_bShowGain[id] = true;
+	g_bShowStrafeList[id] = true;
+	g_bShowFrames[id] = true;
+	g_bShowConsole[id] = true;
+}
+
+public stats_menu(id)
+{
+	new menu = menu_create("\r[FWO] \d- \wDisplay Options", "menu_handler");
+	
+	new szItem[64];
+	
+	formatex(szItem, sizeof(szItem) - 1, "\wStrafes %s", g_bShowStrafes[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "1");
+	
+	formatex(szItem, sizeof(szItem) - 1, "\wSync %s", g_bShowSync[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "2");
+	
+	formatex(szItem, sizeof(szItem) - 1, "\wGain %s", g_bShowGain[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "3");
+
+	formatex(szItem, sizeof(szItem) - 1, "\wFrames %s", g_bShowFrames[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "4");
+	
+	formatex(szItem, sizeof(szItem) - 1, "\wList %s", g_bShowStrafeList[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "5");
+
+	formatex(szItem, sizeof(szItem) - 1, "\wConsole Info %s", g_bShowConsole[id] ? "\y[ON]" : "\r[OFF]");
+	menu_additem(menu, szItem, "6");
+
+	menu_setprop(menu, MPROP_EXITNAME, "Exit");
+	menu_display(id, menu, 0);
+	return PLUGIN_HANDLED;
+}
+
+public menu_handler(id, menu, item){
+	if(item == MENU_EXIT){
+		menu_destroy(menu);
+		return PLUGIN_HANDLED;
+	}
+
+	new data[6], access, callback;
+	menu_item_getinfo(menu, item, access, data, charsmax(data), _, _, callback);
+	new choice = str_to_num(data);
+
+	switch(choice){
+		case 1: g_bShowStrafes[id] = !g_bShowStrafes[id];
+		case 2: g_bShowSync[id] = !g_bShowSync[id];
+		case 3: g_bShowGain[id] = !g_bShowGain[id];
+		case 4: g_bShowFrames[id] = !g_bShowFrames[id];
+		case 5: g_bShowStrafeList[id] = !g_bShowStrafeList[id];
+		case 6: g_bShowConsole[id] = !g_bShowConsole[id];
+	}
+
+	menu_destroy(menu);
+	stats_menu(id);
+	return PLUGIN_HANDLED;
 }
 
 public toggle_stats(id){
-	b_show_stats[id] = !b_show_stats[id];
-	//CC_SendMessage(id, "&x01Stats %s", b_show_stats[id] ? "&x06ON" : "&x07OFF");
+	g_bShowStats[id] = !g_bShowStats[id];
+	//CC_SendMessage(id, "&x01Stats %s", g_bShowStats[id] ? "&x06ON" : "&x07OFF");
 }
 
 public toggle_pre(id){
-	b_pre_stats[id] = !b_pre_stats[id];
-	//CC_SendMessage(id, "&x01ShowPre %s", b_pre_stats[id] ? "&x06ON" : "&x07OFF");
+	g_bPreStats[id] = !g_bPreStats[id];
+	//CC_SendMessage(id, "&x01ShowPre %s", g_bPreStats[id] ? "&x06ON" : "&x07OFF");
 }
 
 public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodFrames, Float:gain, overlaps){
@@ -124,74 +185,111 @@ public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodF
 
 	if(strafes < 1) return;
 	
-	if(b_show_stats[id]){
-		/*
+	if(!g_bShowStats[id]) return;
+
+	// Side list
+	if(g_bShowStrafeList[id]){
 		static szStrafesInfo[32 * MAX_STRAFES], iLen;
-		szStrafesInfo = "^0"; iLen = 0;
+		szStrafesInfo[0] = 0; iLen = 0;
 		for(new i = 0; i < strafeLen && i < MAX_STRAFES; i++)
 		{
-			iLen += formatex(szStrafesInfo[iLen], charsmax(szStrafesInfo) - iLen, "Strafe: %i^tSync: %i^n",
-				i + 1, strafesSync[i]);
+			iLen += formatex(szStrafesInfo[iLen], charsmax(szStrafesInfo) - iLen, "Strafe: %i^tSync: %i^n", i + 1, strafesSync[i]);
 		}
-	
-		set_hudmessage(200, 22, 22, 0.77, 0.4, 0, 0.0, 2.0, 0.2, 0.2, 4);
-		ShowSyncHudMsg(id, g_iStrafeHudSync, "%s", szStrafesInfo);
-
-		set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, 3);
-		ShowSyncHudMsg(id, g_iMainHudSync, "Strafes: %i^nSync: %i%^nFrames: %d/%d^nGain: %.2f", strafes, sync, goodFrames, frames, gain);
-		client_print(id, print_console, "Strafes: %i^nSync: %i%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);
-		*/
 		
-		set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, 3);
-		ShowSyncHudMsg(id, g_iMainHudSync, "STRAFES: %i / SYNC: %i%%^nGAIN: +%.2f^n", strafes, sync, gain);
-		//OLD DESIGN: ShowSyncHudMsg(id, g_iMainHudSync, "Strafes: %i^nSync: %i%^nGain: %.2f", strafes, sync, gain);
+		set_hudmessage(200, 22, 22, 0.77, 0.4, 0, 0.0, 2.0, 0.2, 0.2, 4);
+		ShowSyncHudMsg(id, g_iStrafeHudSync, "%s", szStrafesInfo);	
 	}
 
-	for(new i = 1; i < 33; i++)
-	{
-		if(!is_user_connected(i) || is_user_alive(i) || !b_show_stats[i] ) continue;
+	// Customized center stats
+	static szMain[256]; szMain[0] = 0;
+	
+	if(g_bShowStrafes[id] && g_bShowSync[id] && g_bShowGain[id] && g_bShowFrames[id]){
+		// Original format when everything is ON
+		formatex(szMain, charsmax(szMain), "Strafes: %i / Sync: %i%%^nFrames: %d/%d^nGain: %.2f", strafes, sync, goodFrames, frames, gain);
+	}
+	else{
+		// Customized by removing what's OFF
+		new parts = 0;
 		
-		if( pev(i, pev_iuser2) != id ) continue
+		if(g_bShowStrafes[id]){
+			parts++;
+			formatex(szMain, charsmax(szMain), "Strafes: %i", strafes);
+		}
 		
-		static szStrafesInfo[32 * MAX_STRAFES], iLen;
-		szStrafesInfo = "^0"; iLen = 0;
-		for(new j = 0; j < strafeLen && j < MAX_STRAFES; j++)
-		{
-			iLen += formatex(szStrafesInfo[iLen], charsmax(szStrafesInfo) - iLen, "Strafe: %i^tSync: %i^n",
-				i + 1, strafesSync[j]);
+		if(g_bShowSync[id]){
+			if(parts) add(szMain, charsmax(szMain), " / ");
+			add(szMain, charsmax(szMain), "Sync: ");
+			format(szMain, charsmax(szMain), "%s%i%%", szMain, sync);
+			parts++;
+		}
+		
+		if(g_bShowFrames[id]){
+			if(parts) add(szMain, charsmax(szMain), "^n");
+			format(szMain, charsmax(szMain), "%sFrames: %d/%d", szMain, goodFrames, frames);
+			parts++;
+		}
+		
+		if(g_bShowGain[id]){
+			if(parts) add(szMain, charsmax(szMain), "^n");
+			format(szMain, charsmax(szMain), "%sGain: %.2f", szMain, gain);
+		}
+	}
+
+	if(szMain[0]){
+		set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, 3);
+		ShowSyncHudMsg(id, g_iMainHudSync, "%s", szMain);
+		if(g_bShowConsole[id]){
+			client_print(id, print_console, "--- Strafe #%i - Sync: %i%% ---", strafes, sync);
+			client_print(id, print_console, "Strafes: %i^nSync: %i%%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);
+			client_print(id, print_console, "----------------------------");
+			}
 		}
 
+	// Spectators
+	for(new i = 1; i < 33; i++)
+	{
+		if(!is_user_connected(i) || is_user_alive(i) || !g_bShowStats[i]) continue;
+		
+		if(pev(i, pev_iuser2) != id) continue;
+		
+		static szStrafesInfo[32 * MAX_STRAFES], iLen;
+		szStrafesInfo[0] = 0; iLen = 0;
+		for(new j = 0; j < strafeLen && j < MAX_STRAFES; j++)
+		{
+			iLen += formatex(szStrafesInfo[iLen], charsmax(szStrafesInfo) - iLen, "Strafe: %i^tSync: %i^n", j + 1, strafesSync[j]);
+		}
+		
 		set_hudmessage(200, 22, 22, 0.77, 0.4, 0, 0.0, 2.0, 0.2, 0.2, 4);
 		ShowSyncHudMsg(i, g_iStrafeHudSync, "%s", szStrafesInfo);
 
 		set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, 3);
 		ShowSyncHudMsg(i, g_iMainHudSync, "Strafes: %i^nSync: %i%^nFrames: %d/%d^nGain: %.2f", strafes, sync, goodFrames, frames, gain);
-		//client_print(i, print_console, "Strafes: %i^nSync: %i%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);
+		if(g_bShowConsole[i]){
+			client_print(id, print_console, "--- Strafe #%i - Sync: %i%% ---", strafes, sync);
+			client_print(id, print_console, "Strafes: %i^nSync: %i%%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);
+			client_print(id, print_console, "----------------------------");
+		}
 	}
 }
 
 public fwdPreThink(id) {
-	if (!is_user_alive(id))
-		return FMRES_IGNORED;
+	if (!is_user_alive(id)) return FMRES_IGNORED;
 
-	static button;
-	static flags;
-	static oldbuttons;
-	static Float:velocity[3];
-	static Float:speed;
+	static button, flags, oldbuttons;
+	static Float:velocity[3], Float:speed;
 
 	button = pev(id, pev_button);
 	flags = pev(id, pev_flags);
 	oldbuttons = pev(id, pev_oldbuttons);
 	
-	if(button & IN_JUMP && !(oldbuttons & IN_JUMP)) 
+	if(button & IN_JUMP && !(oldbuttons & IN_JUMP))
 	{
 		if(flags & FL_ONGROUND) {
 			pev(id, pev_velocity, velocity);
 			velocity[2] = 0.0;
 			speed = vector_length(velocity);
 
-			if (b_pre_stats[id]) {
+			if (g_bPreStats[id]) {
 				set_hudmessage(0, 100, 255, -1.0, 0.700, 0, 0.0, 1.0, 0.1, 0.1, 4);
 				ShowSyncHudMsg(id, g_iMainHudSync, "Prestrafe: %.2f", speed);
 			}

--- a/stats.sma
+++ b/stats.sma
@@ -97,7 +97,7 @@ public native_toggle_stats(NumParams){
 
 public native_get_bool_pre(NumParams){
 	new id = get_param(1);
-	return g_bPreStats[id];
+	return g_bShowPre[id];
 }
 
 public native_toggle_pre(NumParams){
@@ -107,7 +107,7 @@ public native_toggle_pre(NumParams){
 
 public client_putinserver(id){ 
 	g_bShowStats[id] = false; // Set to false so stats are OFF by default when the player joins. The player must enable it manually.
-	g_bPreStats[id] = false; // Set to false so Prestrafe is OFF by default (bhop standard). To have it enabled by default (speedrun standard), change to true.
+	g_bShowPre[id] = false; // Set to false so Prestrafe is OFF by default (bhop standard). To have it enabled by default (speedrun standard), change to true.
 	g_bShowStrafes[id] = true;
 	g_bShowSync[id] = true;
 	g_bShowGain[id] = true;
@@ -122,8 +122,8 @@ public toggle_stats(id){
 }
 
 public toggle_pre(id){
-	g_bPreStats[id] = !g_bPreStats[id];
-	//CC_SendMessage(id, "&x01ShowPre %s", g_bPreStats[id] ? "&x06ON" : "&x07OFF");
+	g_bShowPre[id] = !g_bShowPre[id];
+	//CC_SendMessage(id, "&x01ShowPre %s", g_bShowPre[id] ? "&x06ON" : "&x07OFF");
 }
 
 public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodFrames, Float:gain, overlaps){
@@ -237,7 +237,7 @@ public fwdPreThink(id) {
 			velocity[2] = 0.0;
 			speed = vector_length(velocity);
 
-			if (g_bPreStats[id]) {
+			if (g_bShowPre[id]) {
 				set_hudmessage(0, 100, 255, -1.0, 0.700, 0, 0.0, 1.0, 0.1, 0.1, 4);
 				ShowSyncHudMsg(id, g_iMainHudSync, "Prestrafe: %.2f", speed);
 			}

--- a/stats.sma
+++ b/stats.sma
@@ -184,92 +184,92 @@ public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodF
 	g_iNativeSync[id] = sync;
 
 	if(strafes < 1) return;
-	
-	if(!g_bShowStats[id]) return;
 
-	// Side list
-	if(g_bShowStrafeList[id]){
-		static szStrafesInfo[32 * MAX_STRAFES], iLen;
-		szStrafesInfo[0] = 0; iLen = 0;
-		for(new i = 0; i < strafeLen && i < MAX_STRAFES; i++)
+	// List of all players who will receive the HUD: player + spectators    
+	new Array:targets = ArrayCreate();
+	
+	if (g_bShowStats[id])
+		ArrayPushCell(targets, id);
+
+	// Add all spectators
+	for (new i = 1; i < 33; i++)
+	{
+		if (!is_user_connected(i) || is_user_alive(i) || !g_bShowStats[i]) continue;
+		
+		if (pev(i, pev_iuser2) == id)
+			ArrayPushCell(targets, i);
+	}
+
+	// Process all targets uniquely
+	for (new t = 0; t < ArraySize(targets); t++)
+	{
+		new target = ArrayGetCell(targets, t);
+
+		// Side list
+		if(g_bShowStrafeList[target])
 		{
-			iLen += formatex(szStrafesInfo[iLen], charsmax(szStrafesInfo) - iLen, "Strafe: %i^tSync: %i^n", i + 1, strafesSync[i]);
+			static szStrafesInfo[32 * MAX_STRAFES], iLen;
+			szStrafesInfo[0] = 0; iLen = 0;
+			for(new j = 0; j < strafeLen && j < MAX_STRAFES; j++)
+				iLen += formatex(szStrafesInfo[iLen], charsmax(szStrafesInfo) - iLen, "Strafe: %i^tSync: %i^n", j + 1, strafesSync[j]);
+			
+			set_hudmessage(200, 22, 22, 0.77, 0.4, 0, 0.0, 2.0, 0.2, 0.2, 4);
+			ShowSyncHudMsg(target, g_iStrafeHudSync, "%s", szStrafesInfo);
 		}
-		
-		set_hudmessage(200, 22, 22, 0.77, 0.4, 0, 0.0, 2.0, 0.2, 0.2, 4);
-		ShowSyncHudMsg(id, g_iStrafeHudSync, "%s", szStrafesInfo);	
-	}
 
-	// Customized center stats
-	static szMain[256]; szMain[0] = 0;
-	
-	if(g_bShowStrafes[id] && g_bShowSync[id] && g_bShowGain[id] && g_bShowFrames[id]){
-		// Original format when everything is ON
-		formatex(szMain, charsmax(szMain), "Strafes: %i / Sync: %i%%^nFrames: %d/%d^nGain: %.2f", strafes, sync, goodFrames, frames, gain);
-	}
-	else{
-		// Customized by removing what's OFF
-		new parts = 0;
+		// Customized center stats for each target
+		static szMain[256]; szMain[0] = 0;
 		
-		if(g_bShowStrafes[id]){
-			parts++;
-			formatex(szMain, charsmax(szMain), "Strafes: %i", strafes);
+		if(g_bShowStrafes[target] && g_bShowSync[target] && g_bShowGain[target] && g_bShowFrames[target]){
+			// Original format when everything is ON
+			formatex(szMain, charsmax(szMain), "Strafes: %i / Sync: %i%%^nFrames: %d/%d^nGain: %.2f", strafes, sync, goodFrames, frames, gain);
 		}
-		
-		if(g_bShowSync[id]){
-			if(parts) add(szMain, charsmax(szMain), " / ");
-			add(szMain, charsmax(szMain), "Sync: ");
-			format(szMain, charsmax(szMain), "%s%i%%", szMain, sync);
-			parts++;
-		}
-		
-		if(g_bShowFrames[id]){
-			if(parts) add(szMain, charsmax(szMain), "^n");
-			format(szMain, charsmax(szMain), "%sFrames: %d/%d", szMain, goodFrames, frames);
-			parts++;
-		}
-		
-		if(g_bShowGain[id]){
-			if(parts) add(szMain, charsmax(szMain), "^n");
-			format(szMain, charsmax(szMain), "%sGain: %.2f", szMain, gain);
-		}
-	}
-
-	if(szMain[0]){
-		set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, 3);
-		ShowSyncHudMsg(id, g_iMainHudSync, "%s", szMain);
-		if(g_bShowConsole[id]){
-			client_print(id, print_console, "--- Strafe #%i - Sync: %i%% ---", strafes, sync);
-			client_print(id, print_console, "Strafes: %i^nSync: %i%%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);
-			client_print(id, print_console, "----------------------------");
+		else{
+			// Customized by removing what's OFF
+			new parts = 0;
+			
+			if(g_bShowStrafes[target]){
+				parts++;
+				formatex(szMain, charsmax(szMain), "Strafes: %i", strafes);
+			}
+			
+			if(g_bShowSync[target])
+			{
+				if(parts) add(szMain, charsmax(szMain), " / ");
+				add(szMain, charsmax(szMain), "Sync: ");
+				format(szMain, charsmax(szMain), "%s%i%%", szMain, sync);
+				parts++;
+			}
+			
+			if(g_bShowFrames[target])
+			{
+				if(parts) add(szMain, charsmax(szMain), "^n");
+				format(szMain, charsmax(szMain), "%sFrames: %d/%d", szMain, goodFrames, frames);
+				parts++;
+			}
+			
+			if(g_bShowGain[target])
+			{
+				if(parts) add(szMain, charsmax(szMain), "^n");
+				format(szMain, charsmax(szMain), "%sGain: %.2f", szMain, gain);
 			}
 		}
 
-	// Spectators
-	for(new i = 1; i < 33; i++)
-	{
-		if(!is_user_connected(i) || is_user_alive(i) || !g_bShowStats[i]) continue;
-		
-		if(pev(i, pev_iuser2) != id) continue;
-		
-		static szStrafesInfo[32 * MAX_STRAFES], iLen;
-		szStrafesInfo[0] = 0; iLen = 0;
-		for(new j = 0; j < strafeLen && j < MAX_STRAFES; j++)
-		{
-			iLen += formatex(szStrafesInfo[iLen], charsmax(szStrafesInfo) - iLen, "Strafe: %i^tSync: %i^n", j + 1, strafesSync[j]);
+		if(szMain[0]){
+			set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, 3);
+			ShowSyncHudMsg(target, g_iMainHudSync, "%s", szMain);
 		}
 
-		set_hudmessage(200, 22, 22, 0.77, 0.4, 0, 0.0, 2.0, 0.2, 0.2, 4);
-		ShowSyncHudMsg(i, g_iStrafeHudSync, "%s", szStrafesInfo);
-
-		set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, 3);
-		ShowSyncHudMsg(i, g_iMainHudSync, "Strafes: %i / Sync: %i%^nFrames: %d/%d^nGain: %.2f", strafes, sync, goodFrames, frames, gain);
-		if(g_bShowConsole[i]){
-			client_print(id, print_console, "--- Strafe #%i - Sync: %i%% ---", strafes, sync);
-			client_print(id, print_console, "Strafes: %i^nSync: %i%%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);
-			client_print(id, print_console, "----------------------------");
+		// Console info
+		if (g_bShowConsole[target])
+		{
+			client_print(target, print_console, "--- Strafe #%i - Sync: %i%% ---", strafes, sync);
+			client_print(target, print_console, "Strafes: %i^nSync: %i%%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);
+			client_print(target, print_console, "----------------------------");
 		}
 	}
+
+	ArrayDestroy(targets);
 }
 
 public fwdPreThink(id) {

--- a/stats.sma
+++ b/stats.sma
@@ -4,6 +4,7 @@
 #include <hamsandwich>
 #include <cromchat2>
 #include <strafe_globals>
+#include <strafe_menu>
 
 #define PLUGIN "Stats"
 #define VERSION "1.0"
@@ -18,8 +19,8 @@ public plugin_init(){
 
 	register_forward( FM_PlayerPreThink, "fwdPreThink", 0 );
 
-	register_clcmd("say /stats", "toggle_stats");
-	register_clcmd("say /statsmenu", "stats_menu");
+	register_clcmd("say /stats", "StatsMenu");
+	register_clcmd("say /statsmenu", "SettingsMenu");
 
 	register_clcmd("say /pre", "toggle_pre");
 	register_clcmd("say /showpre", "toggle_pre");
@@ -113,59 +114,6 @@ public client_putinserver(id){
 	g_bShowStrafeList[id] = true;
 	g_bShowFrames[id] = true;
 	g_bShowConsole[id] = true;
-}
-
-public stats_menu(id)
-{
-	new menu = menu_create("\r[FWO] \d- \wDisplay Options", "menu_handler");
-	
-	new szItem[64];
-	
-	formatex(szItem, sizeof(szItem) - 1, "\wStrafes %s", g_bShowStrafes[id] ? "\y[ON]" : "\r[OFF]");
-	menu_additem(menu, szItem, "1");
-	
-	formatex(szItem, sizeof(szItem) - 1, "\wSync %s", g_bShowSync[id] ? "\y[ON]" : "\r[OFF]");
-	menu_additem(menu, szItem, "2");
-	
-	formatex(szItem, sizeof(szItem) - 1, "\wGain %s", g_bShowGain[id] ? "\y[ON]" : "\r[OFF]");
-	menu_additem(menu, szItem, "3");
-
-	formatex(szItem, sizeof(szItem) - 1, "\wFrames %s", g_bShowFrames[id] ? "\y[ON]" : "\r[OFF]");
-	menu_additem(menu, szItem, "4");
-	
-	formatex(szItem, sizeof(szItem) - 1, "\wList %s", g_bShowStrafeList[id] ? "\y[ON]" : "\r[OFF]");
-	menu_additem(menu, szItem, "5");
-
-	formatex(szItem, sizeof(szItem) - 1, "\wConsole Info %s", g_bShowConsole[id] ? "\y[ON]" : "\r[OFF]");
-	menu_additem(menu, szItem, "6");
-
-	menu_setprop(menu, MPROP_EXITNAME, "Exit");
-	menu_display(id, menu, 0);
-	return PLUGIN_HANDLED;
-}
-
-public menu_handler(id, menu, item){
-	if(item == MENU_EXIT){
-		menu_destroy(menu);
-		return PLUGIN_HANDLED;
-	}
-
-	new data[6], access, callback;
-	menu_item_getinfo(menu, item, access, data, charsmax(data), _, _, callback);
-	new choice = str_to_num(data);
-
-	switch(choice){
-		case 1: g_bShowStrafes[id] = !g_bShowStrafes[id];
-		case 2: g_bShowSync[id] = !g_bShowSync[id];
-		case 3: g_bShowGain[id] = !g_bShowGain[id];
-		case 4: g_bShowFrames[id] = !g_bShowFrames[id];
-		case 5: g_bShowStrafeList[id] = !g_bShowStrafeList[id];
-		case 6: g_bShowConsole[id] = !g_bShowConsole[id];
-	}
-
-	menu_destroy(menu);
-	stats_menu(id);
-	return PLUGIN_HANDLED;
 }
 
 public toggle_stats(id){

--- a/stats.sma
+++ b/stats.sma
@@ -50,7 +50,7 @@ public plugin_natives(){
 	register_native("toggle_pre", "native_toggle_pre");
 }
 
-public native_get_user_sync(NumParams) {
+public native_get_user_sync(NumParams){
 	new id = get_param(1);
 
 	new sync = g_iNativeSync[id];
@@ -59,7 +59,7 @@ public native_get_user_sync(NumParams) {
 	return sync;
 }
 
-public native_get_user_strafes(NumParams) {
+public native_get_user_strafes(NumParams){
 	new id = get_param(1);
 	
 	new strafes = g_iNativeStrafes[id];
@@ -68,18 +68,16 @@ public native_get_user_strafes(NumParams) {
 	return strafes;
 }
 
-public native_display_stats(NumParams) {
+public native_display_stats(NumParams){
 	
 	new id = get_param(1);
 	new strafes = get_param(2);
 	new sync = get_param(3);
 
-	for(new i = 1; i < 33; i++)
-	{
+	for(new i = 1; i < 33; i++){
 		if(!is_user_connected(i) || is_user_alive(i) || !g_bShowStats[i] ) continue;
 		
-		if( pev(i, pev_iuser2) == id )
-		{
+		if( pev(i, pev_iuser2) == id ){
 			set_hudmessage(0, 100, 255, -1.0, 0.6, 0, 0.0, 2.0, 0.2, 0.2, -1);
 			ShowSyncHudMsg(i, g_iMainHudSync, "Strafes: %i^nSync: %i%%", strafes, sync);
 		}
@@ -124,8 +122,7 @@ public LoadStatsSettings(id){
 
 	get_user_name(id, auth, charsmax(auth));
 
-	if (fvault_get_data(g_iVault, auth, data, charsmax(data)))
-	{
+	if (fvault_get_data(g_iVault, auth, data, charsmax(data))){
 		new values[8] [8];
 		explode_string(data, "#", values, sizeof(values), sizeof(values[]));
 
@@ -183,8 +180,7 @@ public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodF
 		ArrayPushCell(targets, id);
 
 	// Add all spectators
-	for (new i = 1; i < 33; i++)
-	{
+	for (new i = 1; i < 33; i++){
 		if (!is_user_connected(i) || is_user_alive(i) || !g_bShowStats[i]) continue;
 		
 		if (pev(i, pev_iuser2) == id)
@@ -192,13 +188,11 @@ public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodF
 	}
 
 	// Process all targets uniquely
-	for (new t = 0; t < ArraySize(targets); t++)
-	{
+	for (new t = 0; t < ArraySize(targets); t++){
 		new target = ArrayGetCell(targets, t);
 
 		// Side list
-		if(g_bShowStrafeList[target])
-		{
+		if(g_bShowStrafeList[target]){
 			static szStrafesInfo[32 * MAX_STRAFES], iLen;
 			szStrafesInfo[0] = 0; iLen = 0;
 			for(new j = 0; j < strafeLen && j < MAX_STRAFES; j++)
@@ -224,23 +218,20 @@ public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodF
 				formatex(szMain, charsmax(szMain), "Strafes: %i", strafes);
 			}
 			
-			if(g_bShowSync[target])
-			{
+			if(g_bShowSync[target]){
 				if(parts) add(szMain, charsmax(szMain), " / ");
 				add(szMain, charsmax(szMain), "Sync: ");
 				format(szMain, charsmax(szMain), "%s%i%%", szMain, sync);
 				parts++;
 			}
 			
-			if(g_bShowFrames[target])
-			{
+			if(g_bShowFrames[target]){
 				if(parts) add(szMain, charsmax(szMain), "^n");
 				format(szMain, charsmax(szMain), "%sFrames: %d/%d", szMain, goodFrames, frames);
 				parts++;
 			}
 			
-			if(g_bShowGain[target])
-			{
+			if(g_bShowGain[target]){
 				if(parts) add(szMain, charsmax(szMain), "^n");
 				format(szMain, charsmax(szMain), "%sGain: %.2f", szMain, gain);
 			}
@@ -252,8 +243,7 @@ public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodF
 		}
 
 		// Console info
-		if (g_bShowConsole[target])
-		{
+		if (g_bShowConsole[target]){
 			client_print(target, print_console, "--- Strafe #%i - Sync: %i%% ---", strafes, sync);
 			client_print(target, print_console, "Strafes: %i^nSync: %i%%^nFrames: %d/%d^nGain: %.2f^nGain/Strafe: %.2f^nGain/GoodFrames: %.2f", strafes, sync, goodFrames, frames, gain, gain/strafes, gain/goodFrames);
 			client_print(target, print_console, "----------------------------");
@@ -263,7 +253,7 @@ public fwPlayerStrafe(id, strafes, sync, strafesSync[], strafeLen, frames, goodF
 	ArrayDestroy(targets);
 }
 
-public fwdPreThink(id) {
+public fwdPreThink(id){
 	if (!is_user_alive(id)) return FMRES_IGNORED;
 
 	static button, flags, oldbuttons;
@@ -273,8 +263,7 @@ public fwdPreThink(id) {
 	flags = pev(id, pev_flags);
 	oldbuttons = pev(id, pev_oldbuttons);
 	
-	if(button & IN_JUMP && !(oldbuttons & IN_JUMP))
-	{
+	if(button & IN_JUMP && !(oldbuttons & IN_JUMP)){
 		if(flags & FL_ONGROUND) {
 			pev(id, pev_velocity, velocity);
 			velocity[2] = 0.0;
@@ -286,16 +275,14 @@ public fwdPreThink(id) {
 				ArrayPushCell(targets, id);
 
 			// Add all spectators
-			for (new i = 1; i < 33; i++)
-			{
+			for (new i = 1; i < 33; i++){
 				if (!is_user_connected(i) || is_user_alive(i) || !g_bShowPre[i]) continue;
 				
 				if (pev(i, pev_iuser2) == id)
 					ArrayPushCell(targets, i);
 			}
 
-			for (new t = 0; t < ArraySize(targets); t++)
-			{
+			for (new t = 0; t < ArraySize(targets); t++){
 				new target = ArrayGetCell(targets, t);
 				
 				set_hudmessage(0, 100, 255, -1.0, 0.700, 0, 0.0, 1.0, 0.1, 0.1, 4);

--- a/stats.sma
+++ b/stats.sma
@@ -237,10 +237,29 @@ public fwdPreThink(id) {
 			velocity[2] = 0.0;
 			speed = vector_length(velocity);
 
-			if (g_bShowPre[id]) {
-				set_hudmessage(0, 100, 255, -1.0, 0.700, 0, 0.0, 1.0, 0.1, 0.1, 4);
-				ShowSyncHudMsg(id, g_iMainHudSync, "Prestrafe: %.2f", speed);
+			new Array:targets = ArrayCreate();
+			
+			if (g_bShowPre[id])
+				ArrayPushCell(targets, id);
+
+			// Add all spectators
+			for (new i = 1; i < 33; i++)
+			{
+				if (!is_user_connected(i) || is_user_alive(i) || !g_bShowPre[i]) continue;
+				
+				if (pev(i, pev_iuser2) == id)
+					ArrayPushCell(targets, i);
 			}
+
+			for (new t = 0; t < ArraySize(targets); t++)
+			{
+				new target = ArrayGetCell(targets, t);
+				
+				set_hudmessage(0, 100, 255, -1.0, 0.700, 0, 0.0, 1.0, 0.1, 0.1, 4);
+				ShowSyncHudMsg(target, g_iMainHudSync, "Prestrafe: %.2f", speed);
+			}
+
+			ArrayDestroy(targets);
 		}
 	}
 	return FMRES_IGNORED;

--- a/stats.sma
+++ b/stats.sma
@@ -2,6 +2,7 @@
 #include <engine>
 #include <fakemeta>
 #include <hamsandwich>
+#include <fvault>
 #include <cromchat2>
 #include <strafe_globals>
 #include <strafe_menu>
@@ -114,6 +115,48 @@ public client_putinserver(id){
 	g_bShowStrafeList[id] = true;
 	g_bShowFrames[id] = true;
 	g_bShowConsole[id] = true;
+
+	set_task(1.0, "LoadStatsSettings", id);
+}
+
+public LoadStatsSettings(id){
+	new auth[128], data[256];
+
+	get_user_name(id, auth, charsmax(auth));
+
+	if (fvault_get_data(g_iVault, auth, data, charsmax(data)))
+	{
+		new values[8] [8];
+		explode_string(data, "#", values, sizeof(values), sizeof(values[]));
+
+		g_bShowStats[id] = bool:str_to_num(values[0]);
+		g_bShowPre[id] = bool:str_to_num(values[1]);
+		g_bShowStrafes[id] = bool:str_to_num(values[2]);
+		g_bShowSync[id] = bool:str_to_num(values[3]);
+		g_bShowGain[id] = bool:str_to_num(values[4]);
+		g_bShowStrafeList[id] = bool:str_to_num(values[5]);
+		g_bShowFrames[id] = bool:str_to_num(values[6]);
+		g_bShowConsole[id] = bool:str_to_num(values[7]);
+	}
+}
+
+public SaveStatsSettings(id){
+	if (!is_user_connected(id)) return;
+	
+	new auth[128], data[256];
+	get_user_name(id, auth, charsmax(auth));
+	
+	formatex(data, charsmax(data), "%d#%d#%d#%d#%d#%d#%d#%d",
+		g_bShowStats[id],
+		g_bShowPre[id],
+		g_bShowStrafes[id],
+		g_bShowSync[id],
+		g_bShowGain[id],
+		g_bShowStrafeList[id],
+		g_bShowFrames[id],
+		g_bShowConsole[id]
+	);
+	fvault_set_data(g_iVault, auth, data);
 }
 
 public toggle_stats(id){


### PR DESCRIPTION
### Summary
This pull request introduces a complete overhaul and expansion of the strafe statistics HUD system, focusing on customization, usability, and consistency between players and spectators.

### Key Features
- Unified strafe stats HUD shared between players and spectators  
- New HUD design optimized for spectator view  
- Customizable stats display with a main `/stats` menu  
- Player-side menu to toggle individual stat elements (pre-strafe, sync, gain, frames, etc.)  
- Persistent saving/loading of all stat preferences using `fvault`  
- Pre-strafe visibility support for spectators  
- Console logging support for debugging and analysis  

### Improvements & Refactors
- Renamed variables for naming consistency (`g_bPreStats` → `g_bShowPre`)  
- Code formatting improvements (spacing between functions, conditionals, and loops)  
- Internal cleanup to improve readability and long-term maintainability  

### Documentation
- Updated `README.md` to reflect new features and usage instructions  

### Result
This PR delivers a more flexible, maintainable, and user-friendly strafe stats system, enhancing both gameplay feedback for players and visibility for spectators.
