### PR TITLE
Add native to open main stats menu + fix disconnect log error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Vendor directory for dependencies
 dependencies/
+bin/
 
 # Dependency versions lockfile
 pawn.lock

--- a/include/strafe_menu.inc
+++ b/include/strafe_menu.inc
@@ -75,8 +75,9 @@ public SettingsMenu(id)
 
 public SettingsMenu_Handler(id, menu, item){
 	if(item == MENU_EXIT){
+		if(is_user_connected(id))
+			StatsMenu(id);
 		menu_destroy(menu);
-		StatsMenu(id);
 		return PLUGIN_HANDLED;
 	}
 

--- a/include/strafe_stats.inc
+++ b/include/strafe_stats.inc
@@ -13,3 +13,5 @@ native toggle_stats(id);
 
 native get_bool_pre(id);
 native toggle_pre(id);
+
+native open_stats_menu(id);

--- a/stats.sma
+++ b/stats.sma
@@ -48,6 +48,8 @@ public plugin_natives(){
 
 	register_native("get_bool_pre", "native_get_bool_pre");
 	register_native("toggle_pre", "native_toggle_pre");
+
+	register_native("open_stats_menu", "native_open_stats_menu");
 }
 
 public native_get_user_sync(NumParams){
@@ -82,6 +84,11 @@ public native_display_stats(NumParams){
 			ShowSyncHudMsg(i, g_iMainHudSync, "Strafes: %i^nSync: %i%%", strafes, sync);
 		}
 	}
+}
+
+public native_open_stats_menu(NumParams){
+	new id = get_param(1);
+	StatsMenu(id);
 }
 
 public native_get_bool_stats(NumParams){


### PR DESCRIPTION
### Small update:
- Added a native function to open the main stats menu
- Fixed log error when disconnecting with an open menu